### PR TITLE
Baseline pre-commit hooks and Git files - re-merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,102 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Alexander Karatarakis
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the righst
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Common settings that generally should always be used with your language specific settings
+
+# Auto detect text files and perform LF normalization
+# https://www.davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+*          text=auto
+
+#
+# The above will handle all files NOT found below
+#
+
+# Documents
+*.bibtex   text diff=bibtex
+*.doc	        diff=astextplain
+*.DOC	        diff=astextplain
+*.docx          diff=astextplain
+*.DOCX          diff=astextplain
+*.dot           diff=astextplain
+*.DOT           diff=astextplain
+*.pdf           diff=astextplain
+*.PDF           diff=astextplain
+*.rtf           diff=astextplain
+*.RTF	        diff=astextplain
+*.md       text
+*.tex      text diff=tex
+*.adoc     text
+*.textile  text
+*.mustache text
+*.csv      text
+*.tab      text
+*.tsv      text
+*.txt      text
+*.sql      text
+
+# Graphics
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.tif      binary
+*.tiff     binary
+*.ico      binary
+# SVG treated as an asset (binary) by default.
+*.svg      text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg    binary
+*.eps      binary
+
+# Scripts
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.sh       text eol=lf
+# These are explicitly windows files and should use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# Serialisation
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.gz       binary
+*.tar      binary
+*.tgz      binary
+*.zip      binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+#
+# Exclude files from exporting
+#
+
+.gitattributes export-ignore
+.gitignore     export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Created by https://www.gitignore.io/api/linux,windows,visualstudiocode
+# Edit at https://www.gitignore.io/?templates=linux,windows,visualstudiocode
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.gitignore.io/api/linux,windows,visualstudiocode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-case-conflict
+      - id: detect-private-key
+      - id: mixed-line-ending
+        args: [--fix=no]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,10 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         args: [--fix=no]
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v2.2.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,9 @@ repos:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
+
+  - repo: https://github.com/prettier/prettier
+    rev: 1.19.1
+    hooks:
+      - id: prettier
+        name: Prettier

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"]
+};


### PR DESCRIPTION
> **:information_source:** this is a re-merge of PR #1. The last merge between the `feature/pre-commit` and `master` used a rebase, which invalidated all PGP signatures. This PR will use a merge commit instead, preserving commit signatures.

# Git dotfiles
This pull request introduces baseline `.gitignore` and `.gitattributes` files.

## `.gitignore`
The `.gitignore` file has been generated on [gitignore.io](https://gitignore.io), and ignores common files generated by:
- Windows
- Linux
- Visual Studio Code

## `.gitattributes`
The `.gitattributes` file was introduced to manage file endings on files pushed to the repository. We used the [`Common.gitattributes`](https://github.com/alexkaratarakis/gitattributes/blob/809623f5456638a8351291906aad39432c8366f1/Common.gitattributes) file from alexkaratarakis/gitattributes@5a965d3 as a baseline, which sets many other attributes, including appropriate line endings for common file types. Details on the attributes set by this file can be found in commit https://github.com/ShahradR/git-template/commit/18aa76f1885a44b4c34092977f5286bd133b7f1a

# pre-commit
This pull request introduces [pre-commit](https://pre-commit.com) as a Git hook management tool. 

Specifically, this PR introduces eight hooks, listed below. These hooks are to be used in all repositories, and act as a baseline set of checks before commits are pushed upstream. These hooks are:
- [Check Yaml](https://github.com/pre-commit/pre-commit-hooks/blob/d9ccd95055e5e3e6057b41b124857c93280b6bdd/pre_commit_hooks/check_yaml.py)
- [Fix End of Files](https://github.com/pre-commit/pre-commit-hooks/blob/d9ccd95055e5e3e6057b41b124857c93280b6bdd/pre_commit_hooks/end_of_file_fixer.py)
- [Trim Trailing Whitespace](https://github.com/pre-commit/pre-commit-hooks/blob/d9ccd95055e5e3e6057b41b124857c93280b6bdd/pre_commit_hooks/trailing_whitespace_fixer.py)
- [Check for case conflicts](https://github.com/pre-commit/pre-commit-hooks/blob/master/pre_commit_hooks/check_case_conflict.py)
- [Detect Private Key](https://github.com/pre-commit/pre-commit-hooks/blob/master/pre_commit_hooks/detect_private_key.py)
- [Mixed line ending](https://github.com/pre-commit/pre-commit-hooks/blob/d9ccd95055e5e3e6057b41b124857c93280b6bdd/pre_commit_hooks/mixed_line_ending.py)
- [Prettier](https://github.com/prettier/prettier/tree/d746cd73becfa91185f42a7cefb4ebe79145d771)
- [commitlint](https://github.com/alessandrojcm/commitlint-pre-commit-hook/tree/6bc8fdadc259830d59d9904dc22b7fe0d3ffb49a), enforcing the [conventional commit](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) specification

The sections below outline the different hooks introduced in this pull request.

## Check Yaml
This hook checks `.yaml` files for valid syntax, using the [ruamel.yaml](https://pypi.org/project/ruamel.yaml/) YAML loader/dumper for Python.

[![asciicast](https://asciinema.org/a/304129.svg)](https://asciinema.org/a/304129)

## Fix End of Files
UNIX applications typically expect a new line at the end of every file (some examples are the GNU diff and sort tools – [see this StackExchange question for a detailed explanation](https://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file)). This hook ensures that all files pushed to the repository end with a new line.

[![asciicast](https://asciinema.org/a/304097.svg)](https://asciinema.org/a/304097)

## Trim Trailing Whitespace
This hook removes invisible whitespace characters at the end of a line.

[![asciicast](https://asciinema.org/a/304086.svg)](https://asciinema.org/a/304086)

## Check for case conflicts
File names in Linux operating systems are case-sensitive – the files `FILE.txt` and `file.txt` are considered as two distinct files. Windows files, however, are case-insensitive.

To prevent conflicts between the two operating systems, this hook ensures that no two files have the same name, regardless of the case used.

[![asciicast](https://asciinema.org/a/304090.svg)](https://asciinema.org/a/304090)

## Detect Private Key
This hook detects private keys and other secrets that might have been inadvertantly staged, and blocks the commit.

> **Note:** This hook only checks files for [certain keywords](https://github.com/pre-commit/pre-commit-hooks/blob/d9ccd95055e5e3e6057b41b124857c93280b6bdd/pre_commit_hooks/detect_private_key.py#L5-L14) – if a private key is exported as binary (by omitting the `--armor` flag when exporting PGP keys, for example), this hook will not flag the file and allow potentially sensitive data to be committed. Investigating the use of [Talisman](https://thoughtworks.github.io/talisman/) as an alternative.

[![asciicast](https://asciinema.org/a/304082.svg)](https://asciinema.org/a/304082)

## Mixed line endings
This hook flags files that contain both Windows (CRLF) and Linux (LF) file endings.

[![asciicast](https://asciinema.org/a/304109.svg)](https://asciinema.org/a/304109)

## Prettier
This hook runs the [Prettier](https://prettier.io) code formatter on all files before committing.

[![asciicast](https://asciinema.org/a/304492.svg)](https://asciinema.org/a/304492)

## commitlint
This commit-msg hook verifies that commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. A full list of checks can be found [here](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).

> **Note:** This commit hook needs to be installed separately, using `pre-commit install --hook-type commit-msg`

[![asciicast](https://asciinema.org/a/304493.svg)](https://asciinema.org/a/304493)