### PR TITLE
fix(format): fix README.md format for Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # cfn-template
+
 Template repository for AWS CloudFormation templates


### PR DESCRIPTION
Update the README.md file generated by GitHub at repo creation to include a blank line after the first header, to meet Prettier's format specification for Markdown files.

Closes ShahradR/git-template#4