### PR TITLE
feat(action): use the pre-commit GitHub Action

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,17 @@
+name: pre-commit
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+      - name: set PY
+        run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - uses: pre-commit/action@v1.1.0


### PR DESCRIPTION
Use GitHub Actions to run pre-commit checks after each pull request and repo push, providing server-side checks, in addition to the verification done on the client when first creating the commit.

The template used for this workflow was taken from the one provided by pre-commit at [pre-commit/action](https://github.com/pre-commit/action), with some slight modifications.

Closes ShahradR/git-template#3