### PR TITLE
fix(pre-commit): set up Python and Node.js

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
+      - uses: actions/setup-node@v2-beta
       - name: set PY
         run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
       - uses: actions/cache@v1


### PR DESCRIPTION
Explicitly set up Python and Node.js in the pre-commit workflow, in preparation for our custom, slimmed-down act runner.

Version 2 of `setup-python` now downloads Python on self-hosted runners. This is useful when we introduce our slimmed-down act test images, which won't include many of the dependencies actually available to GitHub-hosted runners. See https://github.com/actions/setup-python/releases/tag/v2 for more details.

Similarly, `setup-node` configures Node.js on the runner, allowing JavaScript-based hooks like Prettier to run.

Associated issue: ShahradR/action-taskcat#14