### PR TITLE
feat(action): add support for semantic-release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,9 +1,10 @@
-name: pre-commit
+name: CI workflow
 
 on: [push, pull_request]
 
 jobs:
   pre-commit:
+    name: Run pre-commit checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -16,3 +17,18 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - uses: pre-commit/action@v1.1.0
+
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    needs: [pre-commit]
+    if: ${{ needs.pre-commit.result == 'success' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.0
+        with:
+          node-version: 12
+      - name: Release
+        run: npx semantic-release

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,11 @@
+---
+branches:
+  - main
+  - name: develop
+    prerelease: true
+
+plugins:
+  - "@semantic-release/github"
+  - "@semantic-release/commit-analyzer":
+      preset: conventionalcommits
+  - "@semantic-release/release-notes-generator"


### PR DESCRIPTION
Add a job in the GitHub CI workflow to automatically tag commits in the main and develop branches, based on the commit message headers. As long as the commit messages follow the [Conventional Commits specification](), semantic-release should be able to identify them and create new releases using Git tags.

Releases are only created on the main and develop branches. Releases in the develop branch are marked as pre-release.
# Release on the `main` branch
![main branch tagged as "latest release"](https://user-images.githubusercontent.com/5815058/86301213-421e5880-bbd3-11ea-8851-79ab77669b2f.png)

# Release on the `develop` branch
![develop branch tagged as "pre-release"](https://user-images.githubusercontent.com/5815058/86301261-667a3500-bbd3-11ea-8375-5f7c981e9972.png)

The workflow was also renamed to something more generic, since it no longer exclusively runs pre-commit.

Closes: ShahradR/git-template#8