### PR TITLE
fix(action): bump pre-commit GitHub Action version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,14 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: actions/setup-node@v2-beta
-      - name: set PY
-        run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - uses: pre-commit/action@v1.1.0
+      - uses: pre-commit/action@v2.0.0
 
   release:
     name: Create release


### PR DESCRIPTION
Bump the pre-commit GitHub Action version from v1.1.0 to v2.0.0, which handles caching from within the action itself. This eliminates several tasks from the pre-commit workflow job.

Closes: ShahradR/git-template#9