### PR TITLE
docs(license): update project license to MIT-0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+MIT No Attribution
 
 Copyright (c) 2020 Shahrad Rezaei
 
@@ -7,10 +7,7 @@ of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+furnished to do so.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
Update the project to use the MIT No Attribution (MIT-0) license. Because this project is a template intended to be re-used by other people to build their own projects, it doesn't make much sense to use a license that requires attribution.

To see more details around the license and the reasoning behind it, see:
- [The MIT No Attribution (MIT-0) SPDX entry](https://spdx.org/licenses/MIT-0.html)
- [Roman Mamedov's rationale behind the modified MIT license](https://romanrm.net/mit-zero)
- [Amazon's use of the MIT-0 license and their rationale](https://github.com/aws/mit-0)