### PR TITLE
Bump pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.2.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -13,14 +13,14 @@ repos:
         args: [--fix=no]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v2.2.0
+    rev: v3.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+    rev: 2.1.1
     hooks:
       - id: prettier
         name: Prettier

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This configuration expects the templates to reside under the `templates/` direct
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.2.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -66,14 +66,14 @@ repos:
         args: [--fix=no]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v2.2.0
+    rev: v3.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+    rev: 2.1.1
     hooks:
       - id: prettier
         name: Prettier
@@ -86,7 +86,7 @@ repos:
         entry: jdkato/vale:latest
 
 + - repo: https://github.com/aws-cloudformation/cfn-python-lint
-+   rev: v0.28.2
++   rev: v0.35.1
 +   hooks:
 +     - id: cfn-python-lint
 +       files: templates/.*\.(json|yml|yaml)$
@@ -115,7 +115,7 @@ This version of the file adds the [Haskell Dockerfile Linter](https://github.com
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.2.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -126,14 +126,14 @@ repos:
         args: [--fix=no]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v2.2.0
+    rev: v3.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+    rev: 2.1.1
     hooks:
       - id: prettier
         name: Prettier
@@ -170,7 +170,7 @@ This configuration expects the OpenAPI specification file to reside under the `s
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.2.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -181,14 +181,14 @@ repos:
         args: [--fix=no]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v2.2.0
+    rev: v3.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+    rev: 2.1.1
     hooks:
       - id: prettier
         name: Prettier

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ["@commitlint/config-conventional"]
+  extends: ["@commitlint/config-conventional"],
 };


### PR DESCRIPTION
Bump the pre-commit hook versions to their latest releases. This commit also updates the example pre-commit configurations provided in the README.md file.

This pull request also updates the `commitlint.config.js` file, adding a trailing comma to the `module.exports` JSON object. [This is a new rule enforced by Prettier in version 2.0](https://prettier.io/blog/2020/03/21/2.0.0.html#change-default-value-for-trailingcomma-to-es5-6963httpsgithubcomprettierprettierpull6963-by-fiskerhttpsgithubcomfisker), which adds a dangling comma before closing braces in multiline statements. As a result, Git diffs are cleaner and less code manipulation is required when adding new elements. See Nik Graf's post [_Why you should enforce Dangling Commas for Multiline Statements_](https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8) for the logic behind this change.

Hook versions can be automatically updated by running `pre-commit autoupdate`.