### PR TITLE
fix: set "commit" pre-commit default stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This version of the configuration file adds Java support by:
 
 ```diff
 ---
+default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -110,6 +111,7 @@ The pre-commit configuration has been adapted to lint both JavaScript and TypeSc
 
 ```diff
 ---
+default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -187,6 +189,7 @@ This configuration expects the templates to reside under the `templates/` direct
 
 ```diff
 ---
+default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -247,6 +250,7 @@ This version of the file adds the [Haskell Dockerfile Linter](https://github.com
 
 ```diff
 ---
+default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -302,6 +306,7 @@ This configuration expects the OpenAPI specification file to reside under the `s
 
 ```diff
 ---
+default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Set the default stage for pre-commit to `commit`. This prevents other hooks from running in the `commit-msg` stage, where only the commitlint hook should run to validate the commit message.

This also fixes the issue where the newer Prettier release would fail in the commit-msg stage, after finding no files to lint.

The pre-commit configuration examples in the project's README have also been updated to reflect the changes.