### PR TITLE
fix: reduce size of README GIF, and add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,8 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         args: [--fix=no]
+      - id: check-added-large-files
+        args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v3.0.0

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         args: [--fix=no]
+      - id: check-added-large-files
+        args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v3.0.0
@@ -124,6 +126,8 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         args: [--fix=no]
+      - id: check-added-large-files
+        args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v3.0.0
@@ -202,6 +206,8 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         args: [--fix=no]
+      - id: check-added-large-files
+        args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v3.0.0
@@ -263,6 +269,8 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         args: [--fix=no]
+      - id: check-added-large-files
+        args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v3.0.0
@@ -319,6 +327,8 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         args: [--fix=no]
+      - id: check-added-large-files
+        args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v3.0.0


### PR DESCRIPTION
This pull request reduces the size of the README GIF, demonstrating how to create a repository from this template. Because the animation's size exceeded 10 MB, GitHub is unable to copy files to the new repository, and throws an error.

To prevent this from happening in the future, the [`check-large-added-files`](https://github.com/pre-commit/pre-commit-hooks) hook was introduced, preventing files larger than 10 MB from being pushed to the repository. This commit was also added as part of the standard Git hooks and README examples.

[![asciicast](https://asciinema.org/a/KDhn2pBb2ofXg2vu1CiFGTiXC.svg)](https://asciinema.org/a/KDhn2pBb2ofXg2vu1CiFGTiXC)