### PR TITLE
feat: add Dependabot support to the project

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: fix
+      include: scope


### PR DESCRIPTION
Add the `dependabot.yaml` file to the project, configuring Dependabot for this repository.

This initial configuration keeps GitHub Actions up-to-date with their latest releases. However, depending on the toolset used by repositories based on this Git template, the file might need to be updated with additional package managers or other configuration options best suited for the use case.

The file also configures Dependabot commits to use the Conventional Commits standard by setting the commit-message configuration in the YAML file.

Closes: ShahradR/git-template#14