### PR TITLE
revert(semver): remove changelog plugins

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,7 +34,5 @@ jobs:
       - uses: actions/setup-node@v2.1.2
         with:
           node-version: 12
-      - name: Install dependencies
-        run: npm install @semantic-release/changelog --save-dev
       - name: Release
         run: npx semantic-release

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -9,4 +9,3 @@ plugins:
   - "@semantic-release/commit-analyzer":
       preset: conventionalcommits
   - "@semantic-release/release-notes-generator"
-  - "@semantic-release/changelog"


### PR DESCRIPTION
Given the difficulties in generating a changelog with signed commits (securely managing PGP keys, configuring the workflow to create changelog commits, working around branch policies, etc.), we will rely solely on tags to document new changes, given GitHub's great support for tag messages.

Refs: 70ff09e, 623062c