### PR TITLE
fix(git): bump .gitattributes file version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,16 +32,16 @@
 
 # Documents
 *.bibtex   text diff=bibtex
-*.doc	        diff=astextplain
-*.DOC	        diff=astextplain
-*.docx          diff=astextplain
-*.DOCX          diff=astextplain
-*.dot           diff=astextplain
-*.DOT           diff=astextplain
-*.pdf           diff=astextplain
-*.PDF           diff=astextplain
-*.rtf           diff=astextplain
-*.RTF	        diff=astextplain
+*.doc      diff=astextplain
+*.DOC      diff=astextplain
+*.docx     diff=astextplain
+*.DOCX     diff=astextplain
+*.dot      diff=astextplain
+*.DOT      diff=astextplain
+*.pdf      diff=astextplain
+*.PDF      diff=astextplain
+*.rtf      diff=astextplain
+*.RTF      diff=astextplain
 *.md       text
 *.tex      text diff=tex
 *.adoc     text
@@ -100,3 +100,4 @@
 
 .gitattributes export-ignore
 .gitignore     export-ignore
+.gitkeep       export-ignore


### PR DESCRIPTION
Update the `.gitattributes` file to match the latest changes in the [alexkaratarakis/gitattributes GitHub repository](https://github.com/alexkaratarakis/gitattributes/). Specifically, the following two commits were added since this the file was first included in this project:

  - alexkaratarakis/gitattributes@c198741 Exclude .gitkeep files from exports
  - alexkaratarakis/gitattributes@f017637 Normalize tabs to space