### PR TITLE
fix: bump pre-commit plugin versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -16,14 +16,14 @@ repos:
         args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v3.0.0
+    rev: v4.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+    rev: 2.2.1
     hooks:
       - id: prettier
         name: Prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,8 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
-  - repo: https://github.com/prettier/prettier
-    rev: 2.2.1
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
     hooks:
       - id: prettier
         name: Prettier

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
-  - repo: https://github.com/prettier/prettier
-    rev: 2.2.1
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
     hooks:
       - id: prettier
         name: Prettier
@@ -136,8 +136,8 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
-  - repo: https://github.com/prettier/prettier
-    rev: 2.2.1
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
     hooks:
       - id: prettier
         name: Prettier
@@ -216,8 +216,8 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
-  - repo: https://github.com/prettier/prettier
-    rev: 2.2.1
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
     hooks:
       - id: prettier
         name: Prettier
@@ -279,8 +279,8 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
-  - repo: https://github.com/prettier/prettier
-    rev: 2.2.1
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
     hooks:
       - id: prettier
         name: Prettier
@@ -337,8 +337,8 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
-  - repo: https://github.com/prettier/prettier
-    rev: 2.2.1
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
     hooks:
       - id: prettier
         name: Prettier

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -68,14 +68,14 @@ repos:
         args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v3.0.0
+    rev: v4.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+    rev: 2.2.1
     hooks:
       - id: prettier
         name: Prettier
@@ -117,7 +117,7 @@ default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -130,14 +130,14 @@ repos:
         args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v3.0.0
+    rev: v4.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+    rev: 2.2.1
     hooks:
       - id: prettier
         name: Prettier
@@ -197,7 +197,7 @@ default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -210,14 +210,14 @@ repos:
         args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v3.0.0
+    rev: v4.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+    rev: 2.2.1
     hooks:
       - id: prettier
         name: Prettier
@@ -260,7 +260,7 @@ default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -273,14 +273,14 @@ repos:
         args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v3.0.0
+    rev: v4.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+    rev: 2.2.1
     hooks:
       - id: prettier
         name: Prettier
@@ -318,7 +318,7 @@ default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -331,14 +331,14 @@ repos:
         args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v3.0.0
+    rev: v4.0.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+    rev: 2.2.1
     hooks:
       - id: prettier
         name: Prettier


### PR DESCRIPTION
Bump the pre-commit plugin versions in the `.pre-commit-config.yaml` file and update the examples in the project's README to reflect the new revisions.

This pull request also updates the Prettier pre-commit hook to point to its new mirror repository, located at https://github.com/pre-commit/mirrors-prettier