### PR TITLE
feat: configure Prettier to wrap text at 80 chars

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: preserve


### PR DESCRIPTION
Introduce the .prettierrc.yaml file to the project, and configure Prettier to automatically wrap text when the line exceeds 80 characters, while respecting line breaks in the input.