### PR TITLE
fix: update Node version for semantic-release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,4 +35,4 @@ jobs:
         with:
           node-version: 14.18.1
       - name: Release
-        run: npx semantic-release
+        run: npx semantic-release@v18.0.0


### PR DESCRIPTION
This pull request updates the Release CI job to use the LTS version of Node.js (14.18.1) when invoking semantic-release.

The [semantic-release](https://github.com/semantic-release/semantic-release) project is now leveraging the latest ECMAScript 2017 features without transpilation which requires Node version 14.17 or higher. See the [semantic-release project's FAQ page](https://github.com/semantic-release/semantic-release/blob/a50dc996b5855f4ff6dc2b26e92a1d2296569fb3/docs/support/FAQ.md#why-does-semantic-release-require-node-version--1417) for more details.

This pull request also freezes the semantic-release version used in the Release CI job to v18.0.0, to help prevent job failures caused by updates in the application. This, however, means that the CI pipeline will need to be manually updated when a new version of semantic-release is published.