### PR TITLE
feat: add GitHub Copilot extension to VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   "settings": {},
 
   // Add the IDs of extensions you want installed when the container is created.
-  "extensions": ["esbenp.prettier-vscode"],
+  "extensions": ["esbenp.prettier-vscode", "GitHub.copilot"],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],


### PR DESCRIPTION
Configure the devcontainer to install the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot), making it available to the Visual Studio Code instance running in the container.