### PR TITLE
Install pre-commit to the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,3 +7,5 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 # ** [Optional] Uncomment this section to install additional packages. **
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends vim python3-pip
+
+RUN pip install pre-commit

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,8 @@
     "docker-in-docker": "20.10",
     "docker-from-docker": "20.10",
     "git": "latest",
-    "github-cli": "latest"
+    "github-cli": "latest",
+    "node": "16",
+    "python": "3.10"
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [--maxkb=10240]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v4.0.0
+    rev: v7.0.1
     hooks:
       - id: commitlint
         stages: [commit-msg]


### PR DESCRIPTION
This pull request installs [pre-commit](https://pre-commit.com/) and its depenedencies to the development container, along with the dependencies required by the Git hooks installed by the tool.

This PR also updates alessandrojcm/commitlint-pre-commit-hook pre-commit from v4.0.0 to v7.0.1, to [help resolve a path issue](https://bit.ly/3qTgOMZ).