### PR TITLE
Add support for alex to the Git template

### DIFF
--- a/.alexrc.yaml
+++ b/.alexrc.yaml
@@ -1,0 +1,3 @@
+---
+noBinary: true
+profanitySureness: 1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,11 @@
   "settings": {},
 
   // Add the IDs of extensions you want installed when the container is created.
-  "extensions": ["esbenp.prettier-vscode", "GitHub.copilot"],
+  "extensions": [
+    "esbenp.prettier-vscode",
+    "GitHub.copilot",
+    "TLahmann.alex-linter"
+  ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: alex
+        name: alex
+        entry: alex
+        language: node
+        types: [text]
+        additional_dependencies: [alex]
       - id: dockerfile-provides-entrypoint
         name: Vale
         language: docker_image


### PR DESCRIPTION
This pull request adds [alex](https://github.com/get-alex/alex) as a pre-commit hook, to help find "gender favoring, polarizing, race related, or other unequal phrasing in text", and adds the [AlexJS Linter](https://marketplace.visualstudio.com/items?itemName=TLahmann.alex-linter) Visual Studio Code extension by Tobias Lahmann to the development container configuration, file help to catch errors as code is being written.
    
This pull request also adds the `.alexrc.yaml` file to configure alex to additionally:

- flag gender-binary language (he/she) as an error, favoring gender-neutral language (they) instead
- only flag words with a [cuss](https://github.com/words/cuss/) profanity score of `1` or higher. For example, the word "hook" was being flagged as an error, but had a cuss score of `0`.
    
While alex officially only supports plain text, HTML, MDX, and Markdown files, attempts to configure pre-commit to only search those files by passing them through the "types" array doesn't seem to be working. To have alex search files anyway, the type has been set to "text", which the [identify](https://github.com/pre-commit/identify) library maps to any plain-text file. This will be reviewed in future commits.