### PR TITLE
fix: update pre-commit-hooks and mirrors-prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_stages: [commit]
 exclude: vale/styles/*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.1.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -23,7 +23,7 @@ repos:
         additional_dependencies: ["@commitlint/config-conventional"]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.5.1
     hooks:
       - id: prettier
         name: Prettier


### PR DESCRIPTION
Update the [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks) and [mirrors-prettier](https://github.com/pre-commit/mirrors-prettier) hooks to their latest versions, by running `pre-commit autoupdate`.