### PR TITLE
feat: install pre-commit to the Dockerfile on init

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,6 @@
     "github-cli": "latest",
     "node": "16",
     "python": "3.10"
-  }
+  },
+  "postCreateCommand": ["./.devcontainer/post-create.sh"]
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+pre-commit install --install-hooks
+pre-commit install --install-hooks --hook-type commit-msg


### PR DESCRIPTION
Configure pre-commit and install the environments for all available hooks to the development container after the repository has been cloned, by adding a lifecycle script invoked by the `devcontainer.json` file.

See [_devcontainer.json reference_](https://code.visualstudio.com/docs/remote/devcontainerjson-reference#_lifecycle-scripts) in the Visual Studio Code documentation for more details around development container
lifecycle scripts.