### PR TITLE
feat: make this repository Commitizen-friendly

### DIFF
--- a/.czrc
+++ b/.czrc
@@ -1,0 +1,6 @@
+{
+  "path": "cz-conventional-changelog",
+  "maxHeaderWidth": 50,
+  "maxLineWidth": 72,
+  "closedIssueMessage": "Associated issue: "
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,3 +2,6 @@
 
 pre-commit install --install-hooks
 pre-commit install --install-hooks --hook-type commit-msg
+
+npm install -g commitizen
+npm install -g cz-conventional-changelog

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # git-template
 
-![GitHub workflow](https://img.shields.io/github/workflow/status/ShahradR/git-template/CI%20workflow?logo=github) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![License: MIT-0](https://img.shields.io/badge/license-MIT--0-yellowgreen)](https://spdx.org/licenses/MIT-0.html)
+![GitHub workflow](https://img.shields.io/github/workflow/status/ShahradR/git-template/CI%20workflow?logo=github) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![License: MIT-0](https://img.shields.io/badge/license-MIT--0-yellowgreen)](https://spdx.org/licenses/MIT-0.html) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 Language-agnostic Git template repository to kickstart your projects!
 


### PR DESCRIPTION
Make this repository [Commitizen-friendly](https://github.com/commitizen) by adding a `.czrc` file to the project, and installing the Commitizen CLI and the [Conventional Changelog adaptor](https://github.com/conventional-changelog/conventional-changelog) to the devcontainer.

Commitizen helps teams define a standard way of committing rules and communicating them by providing a CLI that walks contributors through the commit process.

The project's README file was also updated to include the "Commitizen friendly" badge, informing contributors that Commitizen has been set up in this repository, and providing a link to the Commitizen project page.