### PR TITLE
feat: add Yelp's detect-secrets to the project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,4 +8,4 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends vim python3-pip
 
-RUN pip install pre-commit
+RUN pip install pre-commit detect-secrets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,9 @@ repos:
         name: Vale
         language: docker_image
         entry: jdkato/vale:latest
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.3.0
+    hooks:
+      - name: Scan for secrets
+        id: detect-secrets


### PR DESCRIPTION
Add [Yelp's detect-secrets module](https://github.com/Yelp/detect-secrets) to the project, "an enterprise friendly way of detecting and preventing secrets in code". This commit both adds detect-secrets as a pre-commit hook and installs it to the development container.