### PR TITLE
feat: add markdownlint-cli2 and markdown-link-check to this project

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,3 +5,4 @@ pre-commit install --install-hooks --hook-type commit-msg
 
 npm install -g commitizen
 npm install -g cz-conventional-changelog
+npm install -g markdown-link-check

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,3 +6,4 @@ pre-commit install --install-hooks --hook-type commit-msg
 npm install -g commitizen
 npm install -g cz-conventional-changelog
 npm install -g markdown-link-check
+npm install -g markdownlint-cli2

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,254 @@
+# Default state for all rules
+default: true
+
+# Path to configuration file to extend
+extends: null
+
+# MD001/heading-increment/header-increment - Heading levels should only increment by one level at a time
+MD001: true
+
+# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
+MD002:
+  # Heading level
+  level: 1
+
+# MD003/heading-style/header-style - Heading style
+MD003:
+  # Heading style
+  style: "consistent"
+
+# MD004/ul-style - Unordered list style
+MD004:
+  # List style
+  style: "consistent"
+
+# MD005/list-indent - Inconsistent indentation for list items at the same level
+MD005: true
+
+# MD006/ul-start-left - Consider starting bulleted lists at the beginning of the line
+MD006: true
+
+# MD007/ul-indent - Unordered list indentation
+MD007:
+  # Spaces for indent
+  indent: 2
+  # Whether to indent the first level of the list
+  start_indented: false
+  # Spaces for first level indent (when start_indented is set)
+  start_indent: 2
+
+# MD009/no-trailing-spaces - Trailing spaces
+MD009:
+  # Spaces for line break
+  br_spaces: 2
+  # Allow spaces for empty lines in list items
+  list_item_empty_lines: false
+  # Include unnecessary breaks
+  strict: false
+
+# MD010/no-hard-tabs - Hard tabs
+MD010:
+  # Include code blocks
+  code_blocks: true
+  # Fenced code languages to ignore
+  ignore_code_languages: []
+  # Number of spaces for each hard tab
+  spaces_per_tab: 1
+
+# MD011/no-reversed-links - Reversed link syntax
+MD011: true
+
+# MD012/no-multiple-blanks - Multiple consecutive blank lines
+MD012:
+  # Consecutive blank lines
+  maximum: 1
+
+# MD013/line-length - Line length
+MD013:
+  # Number of characters
+  line_length: 80
+  # Number of characters for headings
+  heading_line_length: 80
+  # Number of characters for code blocks
+  code_block_line_length: 80
+  # Include code blocks
+  code_blocks: true
+  # Include tables
+  tables: true
+  # Include headings
+  headings: true
+  # Include headings
+  headers: true
+  # Strict length checking
+  strict: false
+  # Stern length checking
+  stern: false
+
+# MD014/commands-show-output - Dollar signs used before commands without showing output
+MD014: true
+
+# MD018/no-missing-space-atx - No space after hash on atx style heading
+MD018: true
+
+# MD019/no-multiple-space-atx - Multiple spaces after hash on atx style heading
+MD019: true
+
+# MD020/no-missing-space-closed-atx - No space inside hashes on closed atx style heading
+MD020: true
+
+# MD021/no-multiple-space-closed-atx - Multiple spaces inside hashes on closed atx style heading
+MD021: true
+
+# MD022/blanks-around-headings/blanks-around-headers - Headings should be surrounded by blank lines
+MD022:
+  # Blank lines above heading
+  lines_above: 1
+  # Blank lines below heading
+  lines_below: 1
+
+# MD023/heading-start-left/header-start-left - Headings must start at the beginning of the line
+MD023: true
+
+# MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+MD024:
+  # Only check sibling headings
+  allow_different_nesting: false
+  # Only check sibling headings
+  siblings_only: false
+
+# MD025/single-title/single-h1 - Multiple top-level headings in the same document
+MD025:
+  # Heading level
+  level: 1
+  # RegExp for matching title in front matter
+  front_matter_title: "^\\s*title\\s*[:=]"
+
+# MD026/no-trailing-punctuation - Trailing punctuation in heading
+MD026:
+  # Punctuation characters
+  punctuation: ".,;:!。，；：！"
+
+# MD027/no-multiple-space-blockquote - Multiple spaces after blockquote symbol
+MD027: true
+
+# MD028/no-blanks-blockquote - Blank line inside blockquote
+MD028: true
+
+# MD029/ol-prefix - Ordered list item prefix
+MD029:
+  # List style
+  style: "one_or_ordered"
+
+# MD030/list-marker-space - Spaces after list markers
+MD030:
+  # Spaces for single-line unordered list items
+  ul_single: 1
+  # Spaces for single-line ordered list items
+  ol_single: 1
+  # Spaces for multi-line unordered list items
+  ul_multi: 1
+  # Spaces for multi-line ordered list items
+  ol_multi: 1
+
+# MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines
+MD031:
+  # Include list items
+  list_items: true
+
+# MD032/blanks-around-lists - Lists should be surrounded by blank lines
+MD032: true
+
+# MD033/no-inline-html - Inline HTML
+MD033:
+  # Allowed elements
+  allowed_elements:
+    - details
+    - summary
+
+# MD034/no-bare-urls - Bare URL used
+MD034: true
+
+# MD035/hr-style - Horizontal rule style
+MD035:
+  # Horizontal rule style
+  style: "consistent"
+
+# MD036/no-emphasis-as-heading/no-emphasis-as-header - Emphasis used instead of a heading
+MD036:
+  # Punctuation characters
+  punctuation: ".,;:!?。，；：！？"
+
+# MD037/no-space-in-emphasis - Spaces inside emphasis markers
+MD037: true
+
+# MD038/no-space-in-code - Spaces inside code span elements
+MD038: true
+
+# MD039/no-space-in-links - Spaces inside link text
+MD039: true
+
+# MD040/fenced-code-language - Fenced code blocks should have a language specified
+MD040: true
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041:
+  # Heading level
+  level: 1
+  # RegExp for matching title in front matter
+  front_matter_title: "^\\s*title\\s*[:=]"
+
+# MD042/no-empty-links - No empty links
+MD042: true
+
+# MD043/required-headings/required-headers - Required heading structure
+# MD043:
+#   # List of headings
+#   headings: []
+#   # List of headings
+#   headers: []
+
+# MD044/proper-names - Proper names should have the correct capitalization
+MD044:
+  # List of proper names
+  names: []
+  # Include code blocks
+  code_blocks: true
+  # Include HTML elements
+  html_elements: true
+
+# MD045/no-alt-text - Images should have alternate text (alt text)
+MD045: true
+
+# MD046/code-block-style - Code block style
+MD046:
+  # Block style
+  style: "consistent"
+
+# MD047/single-trailing-newline - Files should end with a single newline character
+MD047: true
+
+# MD048/code-fence-style - Code fence style
+MD048:
+  # Code fence style
+  style: "consistent"
+
+# MD049/emphasis-style - Emphasis style should be consistent
+MD049:
+  # Emphasis style should be consistent
+  style: "consistent"
+
+# MD050/strong-style - Strong style should be consistent
+MD050:
+  # Strong style should be consistent
+  style: "consistent"
+
+# MD051/link-fragments - Link fragments should be valid
+MD051: true
+
+# MD052/reference-links-images - Reference links and images should use a label that is defined
+MD052: true
+
+# MD053/link-image-reference-definitions - Link and image reference definitions should be needed
+MD053:
+  # Ignored definitions
+  ignored_definitions: ["//"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,11 @@ repos:
     hooks:
       - id: markdown-link-check
 
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.5.1
+    hooks:
+      - id: markdownlint-cli2
+
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v7.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,11 @@ repos:
       - id: check-added-large-files
         args: [--maxkb=10240]
 
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.10.2
+    hooks:
+      - id: markdown-link-check
+
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v7.0.1
     hooks:

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,6 @@
 printWidth: 80
 proseWrap: preserve
+overrides:
+  - files: "*.md"
+    options:
+      proseWrap: always

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,79 +2,127 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our community include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
 - Demonstrating empathy and kindness toward other people
 - Being respectful of differing opinions, viewpoints, and experiences
 - Giving and gracefully accepting constructive feedback
-- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-- Focusing on what is best not just for us as individuals, but for the overall community
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or email address, without their explicit permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at [INSERT CONTACT
+METHOD]. All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
-**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within the community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla coc].
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder][mozilla coc].
 
-For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][faq]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,57 +1,83 @@
+# Contributing guidelines
+
 Thank you so much for taking the time to contribute to this project! 🥳
 
-This document outlines our contribution guidelines, the steps required to set up your machine and run the code contained in this repository, as well as the style guide and coding conventions used in this project!
+This document outlines our contribution guidelines, the steps required to set up
+your machine and run the code contained in this repository, as well as the style
+guide and coding conventions used in this project!
 
-# Code of conduct
+## Code of conduct
 
-This project and all its participants are governed by our [Code of Conduct](CODE_OF_CONDUCT.md), which has been adapted from version 2.1 of the [Contributor Covenant][contributor-covenant]. Contributors are expected to uphold this code when participating in this project.
+This project and all its participants are governed by our
+[Code of Conduct](CODE_OF_CONDUCT.md), which has been adapted from version 2.1
+of the [Contributor Covenant][contributor-covenant]. Contributors are expected
+to uphold this code when participating in this project.
 
-# Setting up your environment
+## Setting up your environment
 
-This section outlines the setup needed to configure your workspace and start running the code contained in this repository in your environment.
+This section outlines the setup needed to configure your workspace and start
+running the code contained in this repository in your environment.
 
-## Using a development container
+### Using a development container
 
-If you use Visual Studio Code or GitHub Codespaces as your editor, this project includes a [development container][devcontainer] with all the tools required to start development on this project.
+If you use Visual Studio Code or GitHub Codespaces as your editor, this project
+includes a [development container][devcontainer] with all the tools required to
+start development on this project.
 
 To get started on your local machine, you will need:
 
 - [Docker][docker]
-- [Visual Studio Code][vscode] with the [VS Code Remote - Containers extension][remote-containers-extension] installed
+- [Visual Studio Code][vscode] with the [VS Code Remote - Containers
+  extension][remote-containers-extension] installed
 
-Follow the steps in the [Installation section of the _Developing inside a Container_ guide in the Visual Studio Code documentation][install-devcontainer] to get started.
+Follow the steps in the [Installation section of the _Developing inside a
+Container_ guide in the Visual Studio Code documentation][install-devcontainer]
+to get started.
 
-You can also use [GitHub Codespaces][codespaces] for an out-of-the-box experience with no additional setup required.
+> **Warning**</br> The Docker terms and conditions have recently changed. See
+> [_Docker is Updating and Extending Our Product Subscriptions_ on the Docker
+> Blog][codespaces-billing] for more details.
 
-> **Warning**</br>
-> Using GitHub Codespaces might incur additional costs. See [_About billing for GitHub Codespaces_ on GitHub Docs][codespaces-billing] for more details.
+You can also use [GitHub Codespaces][codespaces] for an out-of-the-box
+experience with no additional setup required.
 
-> **Warning**</br>
-> The Docker terms and conditions have recently changed. See [_Docker is Updating and Extending Our Product Subscriptions_ on the Docker Blog][codespaces-billing] for more details.
+> **Warning**</br> Using GitHub Codespaces might incur additional costs. See
+> [_About billing for GitHub Codespaces_ on GitHub Docs][codespaces-billing] for
+> more details.
 
-## Installing the tools directly on your machine
+### Installing the tools directly on your machine
 
 TODO
 
-# Writing commit messages
+## Writing commit messages
 
-Commit messages are the main place where contributors can detail the intent behind changes introduced to the project. By crafting commit messages with care, documentation can be simplified and contributors can use the commit logs to understand the context behind each change.
+Commit messages are the main place where contributors can detail the intent
+behind changes introduced to the project. By crafting commit messages with care,
+documentation can be simplified and contributors can use the commit logs to
+understand the context behind each change.
 
-To understand how commit messages can be useful, it helps to see the different ways they are used:
+To understand how commit messages can be useful, it helps to see the different
+ways they are used:
 
 - `git log` shows a history of commit messages in e-mail format.
 
-- Commit messages can be used to show the commit history for individual lines of code within your editor or by running tools `git blame`
+- Commit messages can be used to show the commit history for individual lines of
+  code within your editor or by running tools `git blame`
 
-- When written using the [Conventional Commits][conventional] standard, releases are automatically created using [semantic-release][semantic-release], according to the [Semantic Versioning][semver] scheme.
+- When written using the [Conventional Commits][conventional] standard, releases
+  are automatically created using [semantic-release][semantic-release],
+  according to the [Semantic Versioning][semver] scheme.
 
-The section below highlights some general guidelines when authoring commits messages for this project.
+The section below highlights some general guidelines when authoring commits
+messages for this project.
 
-## ✔️ Follow the Conventional Commits standard
+### ✔️ Follow the Conventional Commits standard
 
-The [Conventional Commits][conventional] standard specifies how commit messages should be written, in a way that's understood both by computers and humans. It's composed of multiple parts, shown below:
+The [Conventional Commits][conventional] standard specifies how commit messages
+should be written, in a way that's understood both by computers and humans. It's
+composed of multiple parts, shown below:
 
-```
+```text
 <type>[optional scope]: <description>
 
 [optional body]
@@ -61,64 +87,119 @@ The [Conventional Commits][conventional] standard specifies how commit messages 
 
 The `type` field indicates the type of change being introduced by this commit.
 
-The `scope` is optional, and is used to identify components within the project. When Semantic Release generates release notes, it will group changes under the scope.
+The `scope` is optional, and is used to identify components within the project.
+When Semantic Release generates release notes, it will group changes under the
+scope.
 
-The `body` field is optional, but highly recommended. Here, you can add additional details around the change itself, the reasoning behind the commit, as well as any other details that didn't fit in the description.
+The `body` field is optional, but highly recommended. Here, you can add
+additional details around the change itself, the reasoning behind the commit, as
+well as any other details that didn't fit in the description.
 
-The `footer` field is optional, and typically used to add additional details. Common elements include:
+The `footer` field is optional, and typically used to add additional details.
+Common elements include:
 
-- Issues relating to the commit. Most trackers provide the ability to link commits and issues. Commits should use the `Associated issue: ` footer when referencing issues.
+- Issues relating to the commit. Most trackers provide the ability to link
+  commits and issues. Commits should use the `Associated issue:` footer when
+  referencing issues.
 
-- If multiple contributors have helped author an commit, their names can be added by using the `Co-authored-by: ` footer. The GitHub user interface will show multiple avatars next to the commit. See [_Creating a commit with multiple authors_ in the GitHub Docs][co-authored-by] for more details.
+- If multiple contributors have helped author an commit, their names can be
+  added by using the `Co-authored-by:` footer. The GitHub user interface will
+  show multiple avatars next to the commit. See [_Creating a commit with
+  multiple authors_ in the GitHub Docs][co-authored-by] for more details.
 
-- If the commit introduces a breaking change, the `BREAKING CHANGE: ` footer can be used to detail the changes made by the code introduced in this commit. It also instructs Semantic Release to create a new major version.
+- If the commit introduces a breaking change, the `BREAKING CHANGE:` footer can
+  be used to detail the changes made by the code introduced in this commit. It
+  also instructs Semantic Release to create a new major version.
 
-Most editors automatically recognize this commit standard and will provide syntax highlighting out of the box. For example, both Vim and Visual Studio Code will highlight the subject line in red if it exceeds 50 characters, and will also highlight the next line if it contains any text.
+Most editors automatically recognize this commit standard and will provide
+syntax highlighting out of the box. For example, both Vim and Visual Studio Code
+will highlight the subject line in red if it exceeds 50 characters, and will
+also highlight the next line if it contains any text.
 
-This repository is Commitizen-friendly. By running `git cz` or `cz`, the CLI will promt the contributor with a series of questions and help craft a commit message based on the responses. The Commitizen CLI is automatically installed to the devcontainer.
+This repository is Commitizen-friendly. By running `git cz` or `cz`, the CLI
+will promt the contributor with a series of questions and help craft a commit
+message based on the responses. The Commitizen CLI is automatically installed to
+the devcontainer.
 
-## ✔️ Reword your commit if the `commitlint` check fails
+### ✔️ Reword your commit if the `commitlint` check fails
 
-The [commitlint][commitlint] hook is run after the commit message is created to ensure that it adheres to the Conventional Commits standard. However, it only checks the previous commit—if another valid commit is pushed, all checks will pass and the previous message will be ignored. This might cause issues down the line when tools like semantic-release run to generate artifacts based on the commit messages.
+The [commitlint][commitlint] hook is run after the commit message is created to
+ensure that it adheres to the Conventional Commits standard. However, it only
+checks the previous commit—if another valid commit is pushed, all checks will
+pass and the previous message will be ignored. This might cause issues down the
+line when tools like semantic-release run to generate artifacts based on the
+commit messages.
 
-If you need to make changes to your previous commit message, run `git commit --amend` to modify your commit message before pushing it to the remote repository.
+If you need to make changes to your previous commit message, run
+`git commit --amend` to modify your commit message before pushing it to the
+remote repository.
 
-## ✔️ Write atomic commits and pull requests
+### ✔️ Write atomic commits and pull requests
 
-Individual commits should represent a single, complete concept or change. Keeping commits small and atomic helps keep focus on a single topic, simplify communication, and help other contributors understand the changes being introduced. Because atomic commits represent a single self-contained unit of work, they can be rolled-back without greatly affecting the rest of the application.
+Individual commits should represent a single, complete concept or change.
+Keeping commits small and atomic helps keep focus on a single topic, simplify
+communication, and help other contributors understand the changes being
+introduced. Because atomic commits represent a single self-contained unit of
+work, they can be rolled-back without greatly affecting the rest of the
+application.
 
-In the same vein, topic branches should also be focused on a single feature or fix. If changes are being made to multiple unrelated systems, consider splitting the change across multiple topic branches.
+In the same vein, topic branches should also be focused on a single feature or
+fix. If changes are being made to multiple unrelated systems, consider splitting
+the change across multiple topic branches.
 
-> **Note**</br>
-> A good rule of thumb is to look at what the commit message will be. If you find that explaining the changes introduced in your commit is complicated, or fits into more than one type category, that might be an indication that the change needs to be split into multipe commits.
+> **Note**</br> A good rule of thumb is to look at what the commit message will
+> be. If you find that explaining the changes introduced in your commit is
+> complicated, or fits into more than one type category, that might be an
+> indication that the change needs to be split into multipe commits.
 
-For an in-depth review of atomic commits and how they can help with your development process, see [_Make Atomic Git Commits_ by Aleksandr Hovhannisyan][atomic-commits].
+For an in-depth review of atomic commits and how they can help with your
+development process, see [_Make Atomic Git Commits_ by Aleksandr
+Hovhannisyan][atomic-commits].
 
 ### ✔️ Include tests and style changes in the same commit as the code
 
-When introducing new code to the project, tests should be included in the same commit as the feature or fix being added to the project. The `test` type should only be used when adding missing tests or fixing tests for existing code.
+When introducing new code to the project, tests should be included in the same
+commit as the feature or fix being added to the project. The `test` type should
+only be used when adding missing tests or fixing tests for existing code.
 
-Stylistic updates also fall in this category—unless the updates are for existing code already merged into the main branch, avoid using the `style` type.
+Stylistic updates also fall in this category—unless the updates are for existing
+code already merged into the main branch, avoid using the `style` type.
 
-These kinds of splits can happen when trying to fix the code following a GitHub workflow or pre-commit check failure. Avoid introducing commits whose sole purpose is to pass the checks, and favor updating your existing commits instead. This will lead to a more streamlined commit history, and will be better understood by future contributors.
+These kinds of splits can happen when trying to fix the code following a GitHub
+workflow or pre-commit check failure. Avoid introducing commits whose sole
+purpose is to pass the checks, and favor updating your existing commits instead.
+This will lead to a more streamlined commit history, and will be better
+understood by future contributors.
 
 ### ✔️ Edit and clean your commit history before opening a pull request
 
-Your commit history should tell an idealized and "perfected" story of how development has occurred. Commits and the code within them should contain individual, atomic changes, and the history of commits in the branch should narrate a story detailing the code development, without any of the troubleshooting, erroneous commits, or mistakes that happened along the way.
+Your commit history should tell an idealized and "perfected" story of how
+development has occurred. Commits and the code within them should contain
+individual, atomic changes, and the history of commits in the branch should
+narrate a story detailing the code development, without any of the
+troubleshooting, erroneous commits, or mistakes that happened along the way.
 
-Feel free to modify, squash, and split commits in your topic branch before opening a pull request, and present your story in a way that helps future contributors (or even your future self) understand how and why changes were made, without all the extra noise.
+Feel free to modify, squash, and split commits in your topic branch before
+opening a pull request, and present your story in a way that helps future
+contributors (or even your future self) understand how and why changes were
+made, without all the extra noise.
 
-For an in-depth view of how and why cleaning up history is beneficial, see [_Post-Production Editing using Git_ by Seth Robertson][postproduction-git].
+For an in-depth view of how and why cleaning up history is beneficial, see
+[_Post-Production Editing using Git_ by Seth Robertson][postproduction-git].
 
 [contributor-covenant]: https://www.contributor-covenant.org
 [devcontainer]: https://code.visualstudio.com/docs/remote/containers
 [docker]: https://www.docker.com/
 [vscode]: https://code.visualstudio.com/
-[remote-containers-extension]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
-[install-devcontainer]: https://code.visualstudio.com/docs/remote/containers#_installation
+[remote-containers-extension]:
+  https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+[install-devcontainer]:
+  https://code.visualstudio.com/docs/remote/containers#_installation
 [codespaces]: https://github.com/features/codespaces
-[codespaces-billing]: https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces
-[co-authored-by]: https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors
+[codespaces-billing]:
+  https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces
+[co-authored-by]:
+  https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors
 [semver]: https://semver.org/
 [conventional]: https://www.conventionalcommits.org/
 [semantic-release]: https://github.com/semantic-release/semantic-release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # git-template
 
-![GitHub workflow](https://img.shields.io/github/workflow/status/ShahradR/git-template/CI%20workflow?logo=github) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![License: MIT-0](https://img.shields.io/badge/license-MIT--0-yellowgreen)](https://spdx.org/licenses/MIT-0.html) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+![GitHub workflow](https://img.shields.io/github/workflow/status/ShahradR/git-template/CI%20workflow?logo=github)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![License: MIT-0](https://img.shields.io/badge/license-MIT--0-yellowgreen)](https://spdx.org/licenses/MIT-0.html)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
 Language-agnostic Git template repository to kickstart your projects!
 
@@ -8,38 +12,55 @@ Language-agnostic Git template repository to kickstart your projects!
 
 ### Create a new repository from the template
 
-To use this template for your new project, click **"Use this template"** near the top of the page, and select a name for your repository to create it in your own account or organization.
+To use this template for your new project, click **"Use this template"** near
+the top of the page, and select a name for your repository to create it in your
+own account or organization.
 
-![](./docs/images/github-create-repo-from-template.gif)
+![Creating a repository from this template](./docs/images/github-create-repo-from-template.gif)
 
 ### Clone your new repository locally
 
-Once your new repository has been created, clone the repository to your local computer using the `git clone` command.
+Once your new repository has been created, clone the repository to your local
+computer using the `git clone` command.
 
-```
+```shell
 git clone https://github.com/<owner name>/<repository name>
 ```
 
 ### Configure pre-commit
 
-This template is configured to run Git hooks using [pre-commit](https://pre-commit.com/), a "framework for managing and maintaining multi-language pre-commit hooks." Linters and common checks are ran against your commits, catching errors and making sure your code is up to snuff before sharing it with the world!
+This template is configured to run Git hooks using
+[pre-commit](https://pre-commit.com/), a "framework for managing and maintaining
+multi-language pre-commit hooks." Linters and common checks are ran against your
+commits, catching errors and making sure your code is up to snuff before sharing
+it with the world!
 
-After pre-commit is installed (consider using a [Python virtual environment](https://docs.python.org/3/library/venv.html)), run the following command to configure the pre-commit hooks for your repository:
+After pre-commit is installed (consider using a
+[Python virtual environment](https://docs.python.org/3/library/venv.html)), run
+the following command to configure the pre-commit hooks for your repository:
 
-```
+```shell
 pre-commit install && pre-commit install --hook-type commit-msg
 ```
 
-[The pre-commit hooks supplied with this project will cover most situations](https://github.com/ShahradR/git-template/pull/1), but you might wish to add more to the list depending on your requirements. Below are several examples of `.pre-commit-config.yaml` files used for different use cases—use this to tailor your hooks based on your project's needs!
+[The pre-commit hooks supplied with this project will cover most situations](https://github.com/ShahradR/git-template/pull/1),
+but you might wish to add more to the list depending on your requirements. Below
+are several examples of `.pre-commit-config.yaml` files used for different use
+cases—use this to tailor your hooks based on your project's needs!
 
 <details>
 <summary>Java</summary>
 
 This version of the configuration file adds Java support by:
 
-- Augmenting Prettier with [JHipster's Prettier plugin for Java](https://github.com/jhipster/prettier-java)
-- Running [Checkstyle](https://checkstyle.sourceforge.io/) using the pre-commit hook provided by [gherynos/pre-commit-java](https://github.com/gherynos/pre-commit-java)
-  - Checkstyle can also run as a plugin for Ant, Maven, or Gradle. Depending on your use case, you might want to run this check in your build automation tool instead
+- Augmenting Prettier with
+  [JHipster's Prettier plugin for Java](https://github.com/jhipster/prettier-java)
+- Running [Checkstyle](https://checkstyle.sourceforge.io/) using the pre-commit
+  hook provided by
+  [gherynos/pre-commit-java](https://github.com/gherynos/pre-commit-java)
+  - Checkstyle can also run as a plugin for Ant, Maven, or Gradle. Depending on
+    your use case, you might want to run this check in your build automation
+    tool instead
 
 #### Prettier
 
@@ -103,13 +124,22 @@ repos:
 <details>
 <summary>JavaScript/TypeScript</summary>
 
-This version of the file introduces [pre-commit/mirrors-eslint](https://github.com/pre-commit/mirrors-eslint) to run [ESLint](https://eslint.org/), a tool to "find and fix problems in your JavaScript code."
+This version of the file introduces
+[pre-commit/mirrors-eslint](https://github.com/pre-commit/mirrors-eslint) to run
+[ESLint](https://eslint.org/), a tool to "find and fix problems in your
+JavaScript code."
 
-You'll need a valid ESLint configuration file to run this hook—see [Configuring ESLint](https://eslint.org/docs/user-guide/configuring) for details on how to set up your environment.
+You'll need a valid ESLint configuration file to run this hook—see
+[Configuring ESLint](https://eslint.org/docs/user-guide/configuring) for details
+on how to set up your environment.
 
 [![asciicast](https://asciinema.org/a/359740.svg)](https://asciinema.org/a/359740)
 
-The pre-commit configuration has been adapted to lint both JavaScript and TypeScript code. The ESLint plugins required to run the hook must be listed under `additional_dependencies`—this particular example was taken from the [ShahradR/action-taskcat](https://github.com/ShahradR/action-taskcat) project, but you might need to customize the dependency list to fit your needs.
+The pre-commit configuration has been adapted to lint both JavaScript and
+TypeScript code. The ESLint plugins required to run the hook must be listed
+under `additional_dependencies`—this particular example was taken from the
+[ShahradR/action-taskcat](https://github.com/ShahradR/action-taskcat) project,
+but you might need to customize the dependency list to fit your needs.
 
 ```diff
 ---
@@ -178,8 +208,12 @@ repos:
 
 This version of the file adds the following pre-commit checks:
 
-- [CloudFormation Linter](https://github.com/aws-cloudformation/cfn-python-lint) to "validate CloudFormation yaml/json templates against the CloudFormation Resource Specification"
-- [Stelligent cfn_nag](https://github.com/stelligent/cfn_nag) to "look for patterns in CloudFormation templates that may indicate insecure infrastructure"
+- [CloudFormation Linter](https://github.com/aws-cloudformation/cfn-python-lint)
+  to "validate CloudFormation yaml/json templates against the CloudFormation
+  Resource Specification"
+- [Stelligent cfn_nag](https://github.com/stelligent/cfn_nag) to "look for
+  patterns in CloudFormation templates that may indicate insecure
+  infrastructure"
 
 #### CloudFormation Linter
 
@@ -189,7 +223,8 @@ This version of the file adds the following pre-commit checks:
 
 [![asciicast](https://asciinema.org/a/308270.svg)](https://asciinema.org/a/308270)
 
-This configuration expects the templates to reside under the `templates/` directory, at the root of the repository.
+This configuration expects the templates to reside under the `templates/`
+directory, at the root of the repository.
 
 ```diff
 ---
@@ -250,7 +285,10 @@ repos:
 <details>
 <summary>Docker containers</summary>
 
-This version of the file adds the [Haskell Dockerfile Linter](https://github.com/hadolint/hadolint) "a smarter Dockerfile linter that helps you build best practice Docker images" as a pre-commit hook.
+This version of the file adds the
+[Haskell Dockerfile Linter](https://github.com/hadolint/hadolint) "a smarter
+Dockerfile linter that helps you build best practice Docker images" as a
+pre-commit hook.
 
 [![asciicast](https://asciinema.org/a/335409.svg)](https://asciinema.org/a/335409)
 
@@ -306,11 +344,14 @@ repos:
 <details>
 <summary>OpenAPI/Swagger specifications</summary>
 
-This version of the file adds [speccy](https://github.com/wework/speccy) as a pre-commit hook, to "enforce quality rules on your OpenAPI 3.0.x specifications."
+This version of the file adds [speccy](https://github.com/wework/speccy) as a
+pre-commit hook, to "enforce quality rules on your OpenAPI 3.0.x
+specifications."
 
 [![asciicast](https://asciinema.org/a/308584.svg)](https://asciinema.org/a/308584)
 
-This configuration expects the OpenAPI specification file to reside under the `specs/` directory, at the root of the repository.
+This configuration expects the OpenAPI specification file to reside under the
+`specs/` directory, at the root of the repository.
 
 ```diff
 ---
@@ -364,18 +405,28 @@ repos:
 
 ### Configure your continuous integration pipeline
 
-TODO: Configuration steps for GitHub Actions will change once workflow templates are implemented. See [ShahradR/git-template#15](https://github.com/ShahradR/git-template/issues/15) for more details.
+TODO: Configuration steps for GitHub Actions will change once workflow templates
+are implemented. See
+[ShahradR/git-template#15](https://github.com/ShahradR/git-template/issues/15)
+for more details.
 
 ### Update your LICENSE file
 
-This repository is licensed under [MIT No Attribution (MIT-0)](https://spdx.org/licenses/MIT-0.html)—you are free to use this template for your project without the need to worry about attribution.
+This repository is licensed under
+[MIT No Attribution (MIT-0)](https://spdx.org/licenses/MIT-0.html)—you are free
+to use this template for your project without the need to worry about
+attribution.
 
-Update the LICENSE file with a license appropriate for your project! Visit https://choosealicense.com/ to see common open-source licenses.
+Update the LICENSE file with a license appropriate for your project! Visit
+<https://choosealicense.com/> to see common open-source licenses.
 
 ### Update the README file
 
-Once everything has been set up, delete this file and replace it with a README tailored to your project!
+Once everything has been set up, delete this file and replace it with a README
+tailored to your project!
 
 ### Update the Code of Conduct contact information
 
-Update the `[INSERT CONTACT METHOD]` string in the project's Code of Conduct to include an e-mail address owned by a member of your community to help mediate any disputes.
+Update the `[INSERT CONTACT METHOD]` string in the project's Code of Conduct to
+include an e-mail address owned by a member of your community to help mediate
+any disputes.

--- a/vale/README.md
+++ b/vale/README.md
@@ -1,16 +1,26 @@
 # Updating the Microsoft Vale style
 
-To keep this style up-to-date with the different style repositories, this project uses [Gilt] to overlay the source repo's style sub-directory into this repository's `vale/styles/` directory.
+To keep this style up-to-date with the different style repositories, this
+project uses [Gilt] to overlay the source repo's style sub-directory into this
+repository's `vale/styles/` directory.
 
-If a new version of the style is released, follow the steps below to update the git-template with the new version. In this example, the [errata-ai/Microsoft][errata-ai-microsoft] style is used, which implements the [Microsoft Writing Style Guide][microsoft-writing-style-guide].
+If a new version of the style is released, follow the steps below to update the
+git-template with the new version. In this example, the
+[errata-ai/Microsoft][errata-ai-microsoft] style is used, which implements the
+[Microsoft Writing Style Guide][microsoft-writing-style-guide].
 
 ## Clone the `git-template` repository
 
-Unless they're project-specific, all changes to the `vale/` directory and sub-directories should be done in the `git-template` repository. Projects using the template repository can then pull those changes in, and new projects will automatically include the updated styles.
+Unless they're project-specific, all changes to the `vale/` directory and
+sub-directories should be done in the `git-template` repository. Projects using
+the template repository can then pull those changes in, and new projects will
+automatically include the updated styles.
 
 ## Update `gilt.yml` to the latest release
 
-Gilt uses releases to determine which tree to overlay in the repository. When a new tag is released, the `.gilt.yml` file needs to be updated to reflect the latest version.
+Gilt uses releases to determine which tree to overlay in the repository. When a
+new tag is released, the `.gilt.yml` file needs to be updated to reflect the
+latest version.
 
 ### GitHub repository page
 
@@ -28,7 +38,10 @@ Gilt uses releases to determine which tree to overlay in the repository. When a 
 
 ## Run `gilt overlay`
 
-Once the `.gilt.yml` file has been updated, you can run `gilt overlay` to update the files in the `vale/styles` directory.
+Once the `.gilt.yml` file has been updated, you can run `gilt overlay` to update
+the files in the `vale/styles` directory.
+
+<!-- markdownlint-disable line-length -->
 
 ```shell
 $ gilt overlay
@@ -37,7 +50,9 @@ errata-ai.Microsoft:
   - copied (v0.7.0) /home/shahradr/.gilt/clone/github.com/errata-ai.Microsoft/Microsoft/ to /mnt/c/Users/LocalAdmin/workspace/git-template/vale/styles/Microsoft/
 ```
 
-[vale]: https://github.com/errata-ai/vale
+<!-- markdownlint-enable line-length -->
+
 [errata-ai-microsoft]: https://github.com/errata-ai/Microsoft
-[microsoft-writing-style-guide]: https://docs.microsoft.com/en-us/style-guide/welcome/
+[microsoft-writing-style-guide]:
+  https://docs.microsoft.com/en-us/style-guide/welcome/
 [gilt]: https://github.com/retr0h/gilt/


### PR DESCRIPTION
Add support for markdownlint-cli2 and markdown-link-check to this project,

[markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) is "a fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library".

[markdown-link-check](https://github.com/tcort/markdown-link-check) is a tool that "checks that all of the hyperlinks in a Markdown text to determine if they are alive or dead".

Both tools are installed to the development container and added as a pre-commit hook. Existing Markdown files in the project have been updated to match the rules and standards enforced by markdownlint-cli2.