### PR TITLE
docs: add headers when checking GitHub Docs links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     rev: v3.10.2
     hooks:
       - id: markdown-link-check
+        args: [--config, markdown-link-check-config.json]
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.5.1

--- a/markdown-link-check-config.json
+++ b/markdown-link-check-config.json
@@ -1,0 +1,10 @@
+{
+  "httpHeaders": [
+    {
+      "urls": ["https://docs.github.com/"],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add the `Accept-Encoding` headers when checking the GitHub Docs links when using [markdown-link-check](https://github.com/tcort/markdown-link-check) to verify links in Markdown documents. Without the headers, calls to `docs.github.com` fail with an HTTP 403 error.

For more details, see https://bit.ly/3eJgX22 and https://bit.ly/3Tjgoek