### PR TITLE
Enable Material for MkDocs theme

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,7 +3,7 @@
 pre-commit install --install-hooks
 pre-commit install --install-hooks --hook-type commit-msg
 
-pip install codespell mkdocs
+pip install codespell mkdocs mkdocs-material
 
 npm install -g commitizen
 npm install -g cz-conventional-changelog

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -98,10 +98,12 @@ no two files have the same name, regardless of the case used.
 This hook detects private keys and other secrets that might have been
 inadvertently staged, and blocks the commit.
 
-> **Note:** This hook only checks files for [certain
-> keywords][private-key-words]—if a private key is exported as binary (by
-> omitting the `--armor` flag when exporting PGP keys, for example), this hook
-> won't flag the file and allow potentially sensitive data to be committed.
+!!! note
+
+    This hook only checks files for [certain keywords][private-key-words]—if a
+    private key is exported as binary (by omitting the `--armor` flag when
+    exporting PGP keys, for example), this hook won't flag the file and allow
+    potentially sensitive data to be committed.
 
 [![asciicast][asciinema-key-svg]][asciinema-key-link]
 
@@ -125,8 +127,11 @@ This commit-msg hook verifies that commit messages follow the [Conventional
 Commits][conventional-standard] specification. A full list of checks can be
 found [here][conventional-keywords].
 
-> **Note:** This commit hook needs to be installed separately, using
-> `pre-commit install --hook-type commit-msg`
+!!! note
+
+    This commit hook needs to be installed separately from the others, using
+    `pre-commit install --hook-type commit-msg`. This is done automatically
+    when using the development container.
 
 [![asciicast][asciinema-commitlint-svg]][asciinema-commitlint-link]
 
@@ -157,9 +162,15 @@ found [here][conventional-keywords].
 [asciinema-commitlint-svg]: https://asciinema.org/a/304493.svg
 [asciinema-commitlint-link]: https://asciinema.org/a/304493
 [prettier]: https://prettier.io
+
+<!-- markdownlint-disable link-image-reference-definitions -->
+
 [private-key-words]:
   https://github.com/pre-commit/pre-commit-hooks/blob/d9ccd95055e5e3e6057b41b124857c93280b6bdd/pre_commit_hooks/detect_private_key.py#L5-L14
 [conventional-standard]: https://www.conventionalcommits.org/en/v1.0.0/
+
+<!-- markdownlint-enable link-image-reference-definitions -->
+
 [conventional-keywords]:
   https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional
 [hook-yaml]:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,3 +20,7 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,9 @@ site_url: ""
 use_directory_urls: false
 plugins: []
 site_dir: _site
+repo_url: https://github.com/ShahradR/git-template
+repo_name: ShahradR/git-template
+edit_uri: ""
 theme:
   name: material
   palette:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,3 +5,18 @@ plugins: []
 site_dir: _site
 theme:
   name: material
+  palette:
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,3 +3,5 @@ site_url: ""
 use_directory_urls: false
 plugins: []
 site_dir: _site
+theme:
+  name: material


### PR DESCRIPTION
Enable the Material for MkDocs theme in the GitHub Pages documentation site, along with additional features like light/dark themes, admonitions, and repository information.