### PR TITLE
ci: install mkdocs-material during deployment

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Generate MkDocs files
         run: |
-          pip install mkdocs
+          pip install mkdocs mkdocs-material
           mkdocs build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
Install the Material for MkDocs Python library when running the GitHub workflow used to deploy the documentation to GitHub Pages.