### PR TITLE
fix: use the new devcontainer feature syntax

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,12 +32,24 @@
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",
   "features": {
-    "docker-in-docker": "20.10",
-    "docker-from-docker": "20.10",
-    "git": "latest",
-    "github-cli": "latest",
-    "node": "16",
-    "python": "3.10"
+    "ghcr.io/devcontainers/features/docker-in-docker:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/docker-from-docker:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "16"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.10"
+    }
   },
   "postCreateCommand": ["./.devcontainer/post-create.sh"]
 }


### PR DESCRIPTION
Update the devcontainer.json file to use the container image syntax when referencing features, now that they are stored as OCI Artifacts, after their migration from the microsoft/vscode-dev-containers repo to the new devcontainers/features repository.

See https://bit.ly/3gsNcTD for more details.