### PR TITLE
docs: use Material for MkDocs Insiders build

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -35,7 +35,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Generate MkDocs files
         run: |
-          pip install mkdocs mkdocs-material
+          pip install mkdocs
+          pip install --upgrade git+https://${{ secrets.GH_TOKEN }}@github.com/squidfunk/mkdocs-material-insiders.git
           mkdocs build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
Update the CD pipeline to deploy the documentation to GitHub Pages using the Material for MkDocs Insider build, after sponsoring the project.

See https://squidfunk.github.io/mkdocs-material/insiders/ for more details.