### PR TITLE
fix: update sed in cleanup workflow with delete

### DIFF
--- a/.github/workflows/template-cleanup.yaml
+++ b/.github/workflows/template-cleanup.yaml
@@ -32,7 +32,7 @@ jobs:
           rm -f .github/workflows/deploy-pages.yaml
           rm -rf docs/
           sed -i "/- scripts/d" .markdownlint.yaml
-          sed "9;19,25d" .pre-commit-config.yaml
+          sed "9d;19,25d" .pre-commit-config.yaml
 
       - name: Remove project license file
         run: |


### PR DESCRIPTION
Update the sed command when deleting lines from the .pre-commit-config file with the correct syntax. Without adding `d` to the line number, the sed invocation fails with the following error message:

`sed: -e expression #1, char 2: unknown command: ';'`