### PR TITLE
Resolve markdown-link-check and commitlint issues when running pre-commit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,7 +45,7 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "16"
+      "version": "lts"
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.10"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,6 +33,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.0.0
         with:
-          node-version: 14.18.1
+          node-version: lts/*
       - name: Release
         run: npx semantic-release@v18.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v7.0.1
+    rev: v9.18.0
     hooks:
       - id: commitlint
         stages: [commit-msg]


### PR DESCRIPTION
Fix issues with pre-commit hooks failing by:
- Updating the Node.js version used in the CI pipeline and installed in the dev container to the latest LTS version, to resolve errors when running markdown-link-check
- Updating the commitlint pre-commit hook to its latest version to resolve the `ERR_REQUIRE_ESM` error thrown by commitlint since v19.0.0