### PR TITLE
feat: add SSH server feature to the dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,6 +49,9 @@
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.10"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
     }
   },
   "postCreateCommand": ["./.devcontainer/post-create.sh"]


### PR DESCRIPTION
Add the SSH server feature to the dev container, allowing "an external terminal, sftp, or SSHFS to interact with it".

This allows users to connect to the dev container via SSH on the command-line using the GitHub CLI by running `gh codespace ssh -c <CODESPACE-NAME>`

For more details, see:
- https://bit.ly/3UJWn3u for information on how to use the GitHub CLI to connect to a dev container
- https://bit.ly/3CnvITS for information on the SSH server dev container feature